### PR TITLE
Play game trailers automatically on top of snapshots

### DIFF
--- a/xml/View_951_ROM_Console.xml
+++ b/xml/View_951_ROM_Console.xml
@@ -95,6 +95,21 @@
 						<animation effect="fade" start="70" end="100" time="300" reversible="false">Focus</animation>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
+					<!-- Trailer Trigger -->
+					<control type="button">
+						<left>0</left>
+						<top>0</top>
+						<width>1</width>
+						<height>1</height>
+						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
+						<texturefocus>-</texturefocus>
+						<texturenofocus>-</texturenofocus>
+						<animation type="Focus">
+							<effect type="fade" delay="250" start="0" end="100" />
+						</animation>
+					</control>
 				</focusedlayout>
 
 				<itemlayout height="list_item_height" width="list_width">
@@ -318,6 +333,13 @@
 					<texture background="true">$INFO[ListItem.Art(snap)]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
+                <control type="videowindow">
+					<left>890</left>
+                    <top>760</top>
+                    <width>300</width>
+                    <height>230</height>
+                    <visible>Player.Playing + !IsEmpty(ListItem.Trailer)</visible>
+                </control>
 
 				<!-- Flags ===================================================================== -->
 				<!-- Included in MyPrograms.xml -->

--- a/xml/View_952_ROM_MAME.xml
+++ b/xml/View_952_ROM_MAME.xml
@@ -95,6 +95,21 @@
 						<animation effect="fade" start="70" end="100" time="300" reversible="false">Focus</animation>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
+					<!-- Trailer Trigger -->
+					<control type="button">
+						<left>0</left>
+						<top>0</top>
+						<width>1</width>
+						<height>1</height>
+						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
+						<texturefocus>-</texturefocus>
+						<texturenofocus>-</texturenofocus>
+						<animation type="Focus">
+							<effect type="fade" delay="250" start="0" end="100" />
+						</animation>
+					</control>
 				</focusedlayout>
 
 				<itemlayout height="list_item_height" width="list_width">
@@ -340,6 +355,13 @@
 					<texture background="true">$INFO[ListItem.Art(snap)]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
+                <control type="videowindow">
+					<left>890</left>
+                    <top>760</top>
+                    <width>300</width>
+                    <height>230</height>
+                    <visible>Player.Playing + !IsEmpty(ListItem.Trailer)</visible>
+                </control>
 
 				<!-- Flags ===================================================================== -->
 				<!-- Included in MyPrograms.xml -->

--- a/xml/View_953_ROM_Simple.xml
+++ b/xml/View_953_ROM_Simple.xml
@@ -99,6 +99,21 @@
 						<animation effect="fade" start="70" end="100" time="300" reversible="false">Focus</animation>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
+					<!-- Trailer Trigger -->
+					<control type="button">
+						<left>0</left>
+						<top>0</top>
+						<width>1</width>
+						<height>1</height>
+						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
+						<texturefocus>-</texturefocus>
+						<texturenofocus>-</texturenofocus>
+						<animation type="Focus">
+							<effect type="fade" delay="250" start="0" end="100" />
+						</animation>
+					</control>
 				</focusedlayout>
 
 				<itemlayout height="list_item_height" width="list_width">
@@ -234,6 +249,13 @@
 					<texture background="true">$VAR[ROM_Simple_Art_Snap]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
+                <control type="videowindow">
+					<left>740</left>
+                    <top>360</top>
+                    <width>300</width>
+                    <height>240</height>
+                    <visible>Player.Playing + !IsEmpty(ListItem.Trailer)</visible>
+                </control>
 
 				<!-- Metadata ================================================================== -->
 				<control type="group">

--- a/xml/View_954_ROM_Shots.xml
+++ b/xml/View_954_ROM_Shots.xml
@@ -99,6 +99,21 @@
 						<animation effect="fade" start="70" end="100" time="300" reversible="false">Focus</animation>
 						<shadowcolor>text_shadow</shadowcolor>
 					</control>
+					<!-- Trailer Trigger -->
+					<control type="button">
+						<left>0</left>
+						<top>0</top>
+						<width>1</width>
+						<height>1</height>
+						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
+						<texturefocus>-</texturefocus>
+						<texturenofocus>-</texturenofocus>
+						<animation type="Focus">
+							<effect type="fade" delay="250" start="0" end="100" />
+						</animation>
+					</control>
 				</focusedlayout>
 
 				<itemlayout height="list_item_height" width="list_width">
@@ -221,6 +236,13 @@
 					<texture background="true">$VAR[ROM_Simple_Art_Snap]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
+                <control type="videowindow">
+					<left>630</left>
+                    <top>90</top>
+                    <width>560</width>
+                    <height>520</height>
+                    <visible>Player.Playing + !IsEmpty(ListItem.Trailer)</visible>
+                </control>
 
 				<!-- Metadata ================================================================== -->
 				<control type="group">


### PR DESCRIPTION
Hi,

I just made some changes in the console, rom, mame and simple views so that the game trailers are played automatically if found.
They are played on top of the gameplay snapshots and will cover that snapshot while it's playing.

The code is mostly a copy of what you did for the matrix view. There was no need to add nothing new.

Thanks!