### PR TITLE
Escape special characters like commas in video filenames

### DIFF
--- a/xml/View_951_ROM_Console.xml
+++ b/xml/View_951_ROM_Console.xml
@@ -104,7 +104,7 @@
 						<width>1</width>
 						<height>1</height>
 						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
-						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($ESCINFO[ListItem.trailer],1)</onfocus>
 						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
 						<texturefocus>-</texturefocus>
 						<texturenofocus>-</texturenofocus>

--- a/xml/View_952_ROM_MAME.xml
+++ b/xml/View_952_ROM_MAME.xml
@@ -104,7 +104,7 @@
 						<width>1</width>
 						<height>1</height>
 						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
-						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($ESCINFO[ListItem.trailer],1)</onfocus>
 						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
 						<texturefocus>-</texturefocus>
 						<texturenofocus>-</texturenofocus>

--- a/xml/View_953_ROM_Simple.xml
+++ b/xml/View_953_ROM_Simple.xml
@@ -108,7 +108,7 @@
 						<width>1</width>
 						<height>1</height>
 						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
-						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($ESCINFO[ListItem.trailer],1)</onfocus>
 						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
 						<texturefocus>-</texturefocus>
 						<texturenofocus>-</texturenofocus>
@@ -117,6 +117,7 @@
 						</animation>
 					</control>
 					-->
+
 				</focusedlayout>
 
 				<itemlayout height="list_item_height">

--- a/xml/View_954_ROM_Shots.xml
+++ b/xml/View_954_ROM_Shots.xml
@@ -108,7 +108,7 @@
 						<width>1</width>
 						<height>1</height>
 						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
-						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($ESCINFO[ListItem.trailer],1)</onfocus>
 						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
 						<texturefocus>-</texturefocus>
 						<texturenofocus>-</texturenofocus>

--- a/xml/View_970_AEL_Matrix.xml
+++ b/xml/View_970_AEL_Matrix.xml
@@ -91,7 +91,7 @@
 						<width>1</width>
 						<height>1</height>
 						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
-						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($ESCINFO[ListItem.trailer],1)</onfocus>
 						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
 						<texturefocus>-</texturefocus>
 						<texturenofocus>-</texturenofocus>

--- a/xml/View_971_AEL_Properties.xml
+++ b/xml/View_971_AEL_Properties.xml
@@ -91,7 +91,7 @@
 						<width>1</width>
 						<height>1</height>
 						<onload condition="!IsEmpty(ListItem.Trailer)">PlayerControl(Repeat)</onload>
-						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($INFO[ListItem.trailer],1)</onfocus>
+						<onfocus condition="!IsEmpty(ListItem.Trailer)">PlayMedia($ESCINFO[ListItem.trailer],1)</onfocus>
 						<onunfocus condition="Player.HasVideo">PlayerControl(Stop)</onunfocus>
 						<texturefocus>-</texturefocus>
 						<texturenofocus>-</texturenofocus>


### PR DESCRIPTION
This fix just uses the `ESCINFO` function. I know its commented out currently, but it would be helpful in the future if used.

[https://github.com/Wintermute0110/skin.estuary.AEL/issues/2](https://github.com/Wintermute0110/skin.estuary.AEL/issues/2)